### PR TITLE
Add PageGuard - free website health scanner for JAMstack sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ to global deployment.
 * [Commerce Layer](https://commercelayer.io) - Headless commerce platform and order management system that lets you add global shopping capabilities to any website, mobile app, chatbot, or IoT device, with ease.
 * [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components and Jamstack websites visually.
 * [Snipcart](https://snipcart.com) - Shopping cart you can simply add to any of your favorite website stack.
+* [PageGuard](https://pageguard.org) - Free website health scanner for ADA/WCAG accessibility, SEO, performance, and best practices in one scan.
 
 ## Articles
 


### PR DESCRIPTION
## Description
Adds [PageGuard](https://pageguard.org) — a free all-in-one website health scanner. It scans SEO, ADA/WCAG accessibility, Core Web Vitals performance, and best practices — making it perfect for JAMstack site quality auditing.

## Checklist
- [x] The link is working
- [x] Follows existing format  
- [x] Added in appropriate section