### PR TITLE
Add Hakanai Broadcast to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ to global deployment.
 * [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components and Jamstack websites visually.
 * [Snipcart](https://snipcart.com) - Shopping cart you can simply add to any of your favorite website stack.
 * [PageGuard](https://pageguard.org) - Free website health scanner for ADA/WCAG accessibility, SEO, performance, and best practices in one scan.
+* [Hakanai Broadcast](https://broadcast.hakanai.io) - Turn your site's RSS feed into an email newsletter and auto-post new content to social networks.
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to global deployment.
 * [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components and Jamstack websites visually.
 * [Snipcart](https://snipcart.com) - Shopping cart you can simply add to any of your favorite website stack.
 * [PageGuard](https://pageguard.org) - Free website health scanner for ADA/WCAG accessibility, SEO, performance, and best practices in one scan.
-* [Hakanai Broadcast](https://broadcast.hakanai.io) - Turn your site's RSS feed into an email newsletter and auto-post new content to social networks.
+* [Hakanai Broadcast](https://broadcast.hakanai.io) - Turn your site's RSS feed into an email newsletter and automatically post new content to social networks.
 
 ## Articles
 


### PR DESCRIPTION
Adds [Hakanai Broadcast](https://broadcast.hakanai.io), a tool that turns a site's RSS feed into an email newsletter and auto-posts new content to social networks. Useful for JAMstack sites that have no server to run a newsletter from. Disclosure: I'm the maker.