### PR TITLE
Add HonorBox to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ to global deployment.
 * [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components and Jamstack websites visually.
 * [Snipcart](https://snipcart.com) - Shopping cart you can simply add to any of your favorite website stack.
 * [PageGuard](https://pageguard.org) - Free website health scanner for ADA/WCAG accessibility, SEO, performance, and best practices in one scan.
+* [HonorBox](https://honorboxx.github.io/honorbox/) - Sell digital products from your Jamstack site with just Stripe and GitHub.
 
 ## Articles
 


### PR DESCRIPTION
Adds [HonorBox](https://honorboxx.github.io/honorbox/) to Useful Tools.

HonorBox is an MIT-licensed tool for selling digital products from a static/Jamstack site: storefront builds to GitHub Pages, checkout is Stripe Payment Links on your own account, and a scheduled GitHub Action fulfills sales by inviting each buyer's GitHub account to a private repo — no server, no platform fee. Repo: https://github.com/Honorboxx/honorbox (live demo: the project's own store).

Disclosure: I maintain the project.