### PR TITLE
Add YunCMS to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ to global deployment.
 * [HonorBox](https://honorboxx.github.io/honorbox/) - Sell digital products from your Jamstack site with just Stripe and GitHub.
 * [Hakanai Broadcast](https://broadcast.hakanai.io) - Turn your site's RSS feed into an email newsletter and automatically post new content to social networks.
 * [JustBlogged](https://justblogged.com/) - A no-setup blogging platform with built-in SEO, custom domains, and beautiful themes.
+* [YunCMS](https://github.com/Yunsoft-Software/yuncms) - Self-hosted MySQL CMS and REST backend with a React Studio, role-based access control, Files and optional MCP.
 
 ## Articles
 


### PR DESCRIPTION
Adds [YunCMS](https://github.com/Yunsoft-Software/yuncms) to the bottom of Useful Tools in the requested Name, link, and short-description format. YunCMS is a public MIT-licensed, self-hosted MySQL CMS and REST backend whose API can serve Jamstack frontends.

The project currently documents its 0.1.x line as pre-stable.

Validation: git diff --check passed. npx awesome-lint was also run; the target has pre-existing list-wide findings, and the new YunCMS line was not cited.

Disclosure: I am submitting this on behalf of the YunCMS project.